### PR TITLE
Debug yolov11 channel mismatch error

### DIFF
--- a/tests/test_model_integrity.py
+++ b/tests/test_model_integrity.py
@@ -1,0 +1,15 @@
+import pytest
+import torch
+from ultralytics import YOLO
+
+CONFIG_PATH = "LMWP-YOLO-main/yolov11-lcnet-mafrneck.yaml"
+
+@pytest.mark.parametrize("img_size", [256, 320])
+def test_model_forward(img_size):
+    """Build the model and ensure a dummy forward pass succeeds without runtime errors."""
+    model = YOLO(CONFIG_PATH).model  # DetectionModel instance
+    x = torch.randn(1, 3, img_size, img_size)
+    preds = model(x)
+    # Detect head returns a tuple of predictions and None (train outputs)
+    assert isinstance(preds, (list, tuple)), "Forward should return a list/tuple"
+    assert len(preds[0]) == model.model[-1].nl, "Number of detection layers should match"

--- a/ultralytics/nn/tasks.py
+++ b/ultralytics/nn/tasks.py
@@ -1735,6 +1735,12 @@ def parse_model(d, ch, verbose=True):
             args = [c1, c2, *args[1:]]
         elif m is CBFuse:
             c2 = ch[f[-1]]
+        elif m is MAFR:
+            # MAFR expects a single `inp` argument which should equal the incoming
+            # channel count. Ignore YAML-provided value to prevent mismatches
+            # after width scaling.
+            args = [ch[f]]  # ensure inp matches previous layer's channels
+            c2 = ch[f]
         elif m in frozenset({TorchVision, Index}):
             c2 = args[0]
             c1 = ch[f]
@@ -1881,8 +1887,15 @@ def _set_out_channels(module):
     if hasattr(module, "conv") and isinstance(module.conv, torch.nn.Conv2d):
         module.out_channels = module.conv.out_channels
     # Case 2: blocks that end with a Conv named `cv2` (e.g. C3*, C2f*)
-    elif hasattr(module, "cv2") and isinstance(module.cv2, torch.nn.Conv2d):
-        module.out_channels = module.cv2.out_channels
+    # Support both raw nn.Conv2d layers and wrapped Conv modules used across Ultralytics repo.
+    elif hasattr(module, "cv2"):
+        cv2_layer = module.cv2
+        # If it's a wrapped Conv, drill down to the underlying nn.Conv2d stored in attribute `conv`.
+        if isinstance(cv2_layer, torch.nn.Module):
+            if isinstance(cv2_layer, torch.nn.Conv2d):
+                module.out_channels = cv2_layer.out_channels
+            elif hasattr(cv2_layer, "conv") and isinstance(cv2_layer.conv, torch.nn.Conv2d):
+                module.out_channels = cv2_layer.conv.out_channels
     # Fallback: search first child Conv
     elif not hasattr(module, "out_channels"):
         # Choose the *last* Conv2d encountered (closest to the module output)


### PR DESCRIPTION
Fixes channel mismatch errors in YOLOv11-LCNet-MAFRNeck model parsing by correcting channel calculation for wrapped convolutions and MAFR layers.

The model parsing logic had two issues: `_set_out_channels` failed to correctly resolve output channels for wrapped `Conv` blocks (e.g., within C2PSA), and the `MAFR` layer's input channel count was hardcoded instead of being dynamically derived from the preceding layer's output, causing `RuntimeError` due to channel mismatches.

---

[Open in Web](https://cursor.com/agents?id=bc-546faacf-592b-411e-8f03-9928333df04e) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-546faacf-592b-411e-8f03-9928333df04e)

Learn more about [Background Agents](https://docs.cursor.com/background-agent/web-and-mobile)